### PR TITLE
Enhance with :require_order option and string argument can start with…

### DIFF
--- a/lib/ruby-getoptions.rb
+++ b/lib/ruby-getoptions.rb
@@ -205,6 +205,14 @@ private
       option_result = {}
       remaining_args = []
       while args.size > 0
+        # If we require order, then push all to remaining once we see an arg that is not an option, i.e.
+        #   does not start with '-' and is not a known option
+        isCmd, dummy = isOption?(args.flatten[0], mode)
+        ## puts "DEBUG: isCmd[0] #{isCmd[0]}  Args0: #{args[0]}"
+        if @options[:require_order] && @option_map.keys.flatten.grep(isCmd[0]).empty? && args[0][0] != '-'
+          remaining_args.push(*args)
+          return option_result, remaining_args
+        end
         arg = args.shift
         options, argument = isOption?(arg, mode)
         if options.size >= 1 && options[0] == '--'
@@ -412,7 +420,14 @@ private
     end
 
     def self.process_desttype_arg(args, opt_match, optional, required = false)
-      if !args[0].nil? && option?(args[0])
+
+###
+      # If this arg exists, is required, and is string type, just use it
+      if !args[0].nil? && @option_map[opt_match][:arg_opts][0] == 's' && !optional
+        arg = process_option_type(args.shift, opt_match, optional)
+###
+
+      elsif !args[0].nil? && option?(args[0])
         debug "args[0] option"
         if required
           return args, nil


### PR DESCRIPTION
… '-'.

Add 'require_order' option so that first 'unknown' token terminates parsing
in the same way that '--' terminates parsing.  This option is manifested in
iterate_over_arguments function.

Fix process_desttype_arg so that an argument to a string-type option is NOT
processed to see if it looks like an option itself.  Allows the string argument
to start with a '-' character (allows passing of options as the argument to an
option).
